### PR TITLE
Warn about multiple registrations, but continue running

### DIFF
--- a/test-fixture.html
+++ b/test-fixture.html
@@ -309,8 +309,12 @@ large quantity of ever-growing set-up and tear-down boilerplate.
       );
     });
 
-  document.registerElement('test-fixture', {
-    prototype: TestFixturePrototype
-  });
+  try {
+    document.registerElement('test-fixture', {
+      prototype: TestFixturePrototype
+    });
+  } catch (e) {
+    console.warn('test-fixture has already been registered!');
+  }
 })();
 </script>

--- a/test-fixture.html
+++ b/test-fixture.html
@@ -314,7 +314,11 @@ large quantity of ever-growing set-up and tear-down boilerplate.
       prototype: TestFixturePrototype
     });
   } catch (e) {
-    console.warn('test-fixture has already been registered!');
+    if (window.WCT) {
+      console.warn('if you are using WCT, you do not need to manually import test-fixture.html');
+    } else {
+      console.warn('test-fixture has already been registered!');
+    }
   }
 })();
 </script>

--- a/test/handle-multiple-registrations.html
+++ b/test/handle-multiple-registrations.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Multiple Registrations</title>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../test-fixture.html">
+  <link rel="import" href="test-fixture-symlink.html">
+</head>
+<body>
+  <script>
+    test('multiple registrations', function() {
+      var imports = document.querySelectorAll('link[rel="import"]');
+      for (var i = 0; i < imports.length; i++) {
+        assert.ok(imports[i].import, 'import loaded');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -20,7 +20,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <script>
       WCT.loadSuites([
-	      'test-fixture.html'
+        'test-fixture.html',
+        'handle-multiple-registrations.html'
       ]);
     </script>
   </body>

--- a/test/test-fixture-symlink.html
+++ b/test/test-fixture-symlink.html
@@ -1,0 +1,1 @@
+../test-fixture.html

--- a/test/test-fixture.html
+++ b/test/test-fixture.html
@@ -15,7 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../test-fixture.html">
+  <link rel="import" id="test-fixture-import" href="../test-fixture.html">
 </head>
 <body>
   <script>
@@ -82,6 +82,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
   <script>
+describe('test-fixture import', function() {
+  it('loads from test-fixture import', function() {
+    var importNode = document.getElementById('test-fixture-import');
+    expect(importNode.import).to.not.be.null;
+  });
+});
 describe('<test-fixture>', function () {
   var trivialFixture;
   var complexDomFixture;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,5 @@
+{
+  "clientOptions": {
+    "environmentImports": []
+  }
+}


### PR DESCRIPTION
Test-fixtures inclusion into WCT has made a few projects that use test-fixture
separately fail because test-fixture can be registered by WCT with a different path.