### PR TITLE
Fix fixtures returning undefined in Safari 7.

### DIFF
--- a/test-fixture.html
+++ b/test-fixture.html
@@ -155,7 +155,9 @@ large quantity of ever-growing set-up and tear-down boilerplate.
 
     get fixtureTemplates () {
       if (!this._fixtureTemplates) {
-        this._fixtureTemplates = this.querySelectorAll('template');
+        // Copy fixtures to a true Array for Safari 7. This prevents their
+        // `content` property from being improperly garbage collected.
+        this._fixtureTemplates = Array.prototype.slice.apply(this.querySelectorAll('template'));
       }
 
       return this._fixtureTemplates;


### PR DESCRIPTION
Recently a bunch of tests across PolymerElements repos started failing in Safari 7 because `fixture` started returning undefined. I noticed while digging around that whenever I logged a template to the console in test-fixture, the tests didn't fail. I put them in a global array during `create`, still didn't fail. Then I tried this splice and it seems to work just as well. My guess is that Safari 7 sometimes GCs properties of elements in NodeLists (even non-live). Given that test-fixture uses `_fixtureTemplates` as if it was an array, we might as well make it a real one. I think this is a plausible reason behind why the point where `fixture` starts failing isn't deterministic. This might be something better fixed in webcomponents.js though.