### PR TITLE
<test-fixture> now works with Custom Elements v1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,8 @@
   ],
   "devDependencies": {
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "webcomponentsjs-v1": "webcomponents/webcomponentsjs#v1-polymer-edits"
   },
   "main": "test-fixture.html",
   "ignore": []

--- a/test-fixture.html
+++ b/test-fixture.html
@@ -313,9 +313,20 @@ large quantity of ever-growing set-up and tear-down boilerplate.
     });
 
   try {
-    document.registerElement('test-fixture', {
-      prototype: TestFixturePrototype
-    });
+    if (window.customElements) {
+      function TestFixture() {
+        return ((window.Reflect && Reflect.construct) ?
+            Reflect.construct(HTMLElement, [], TestFixture)
+            : HTMLElement.call(this)) || this;
+      }
+      TestFixture.prototype = TestFixturePrototype;
+      TestFixture.prototype.constructor = TestFixture;
+      customElements.define('test-fixture', TestFixture);
+    } else {
+      document.registerElement('test-fixture', {
+        prototype: TestFixturePrototype
+      });
+    }
   } catch (e) {
     if (window.WCT) {
       console.warn('if you are using WCT, you do not need to manually import test-fixture.html');

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       WCT.loadSuites([
         'test-fixture.html',
+        'test-fixture-v1.html',
         'handle-multiple-registrations.html'
       ]);
     </script>

--- a/test/test-fixture-v1.html
+++ b/test/test-fixture-v1.html
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>test-fixture</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../webcomponentsjs-v1/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" id="test-fixture-import" href="../test-fixture.html">
@@ -21,17 +21,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     (function() {
-      var proto = Object.create(HTMLElement.prototype);
+      function XCustom() {
+        if (window.Reflect) {
+          return Reflect.construct(HTMLElement, [], XCustom)
+        }
+        return HTMLElement.call(this) || this;
+      }
 
-      proto.onDetached = function() {};
-
-      proto.detachedCallback = function() {
+      XCustom.constructor = XCustom;
+      XCustom.prototype = Object.create(HTMLElement.prototype);
+      XCustom.prototype.onDetached = function() {};
+      XCustom.prototype.disconnectedCallback = function() {
         this.onDetached();
       };
 
-      document.registerElement('x-custom', {
-        prototype: proto
-      });
+      customElements.define('x-custom', XCustom);
     })();
   </script>
   <test-fixture id="TrivialFixture">


### PR DESCRIPTION
This change features a mechanism for expressing `<test-fixture>` implementation as a class, without requiring us to write a mostly-duplicated fork of the implementation. Also, a test suite has been added to test the element under the Custom Elements v1 polyfill.
