### PR TITLE
force synchrony for ShadyDOM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "webcomponentsjs-v1": "webcomponents/webcomponentsjs#v1-polymer-edits"
+    "webcomponentsjs-v1": "webcomponents/webcomponentsjs#v1"
   },
   "main": "test-fixture.html",
   "ignore": []

--- a/test-fixture.html
+++ b/test-fixture.html
@@ -240,6 +240,10 @@ large quantity of ever-growing set-up and tear-down boilerplate.
       if (window.CustomElements && window.CustomElements.takeRecords) {
         window.CustomElements.takeRecords();
       }
+      // Force synchrony in ShadyDOM in case we are dealing with the polyfill.
+      if (window.ShadyDOM) {
+        window.ShadyDOM.flush();
+      }
     },
 
     collectElementChildren: function (parent) {

--- a/test-fixture.html
+++ b/test-fixture.html
@@ -235,12 +235,15 @@ large quantity of ever-growing set-up and tear-down boilerplate.
 
     forcePolyfillAttachedStateSynchrony: function () {
       // Force synchrony in attachedCallback and detachedCallback where
-      // implemented, in the event that we are dealing with the async Web
-      // Components Polyfill.
-      if (window.CustomElements && window.CustomElements.takeRecords) {
+      // implemented, in the event that we are dealing with one of these async
+      // polyfills:
+      // 1. Web Components CustomElements polyfill (v1 or v0).
+      if (window.customElements && window.customElements.flush) {
+        window.customElements.flush();
+      } else if (window.CustomElements && window.CustomElements.takeRecords) {
         window.CustomElements.takeRecords();
       }
-      // Force synchrony in ShadyDOM in case we are dealing with the polyfill.
+      // 2. ShadyDOM polyfill.
       if (window.ShadyDOM) {
         window.ShadyDOM.flush();
       }

--- a/test/index.html
+++ b/test/index.html
@@ -15,15 +15,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
-    <link rel="import" href="../../polymer/polymer.html">
-
   </head>
   <body>
     <script>
       WCT.loadSuites([
-        'test-fixture.html',
-        'test-fixture-v1.html',
-        'handle-multiple-registrations.html'
+        'test-fixture.html', // shady
+        'test-fixture.html?dom=shadow', // shadow
+        'test-fixture-v1.html?wc-shadydom=true&wc-ce=true', // shady
+        'test-fixture-v1.html', // shadow
+        'handle-multiple-registrations.html',
       ]);
     </script>
   </body>

--- a/test/test-fixture-v1.html
+++ b/test/test-fixture-v1.html
@@ -21,6 +21,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     (function() {
+      // Flag to enable takeRecords/flush for CustomElements v1 polyfill.
+      // https://github.com/webcomponents/custom-elements#differences-from-spec
+      customElements.enableFlush = true;
+
       function XCustom() {
         if (window.Reflect) {
           return Reflect.construct(HTMLElement, [], XCustom)

--- a/test/test-fixture-v1.html
+++ b/test/test-fixture-v1.html
@@ -12,6 +12,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <title>test-fixture</title>
 
+  <script>
+    // Save original HTMLElement constructor since customElements v1 polyfill
+    // overrides it https://github.com/webcomponents/webcomponentsjs/issues/623
+    var _HTMLElement = window.HTMLElement;
+  </script>
+
   <script src="../../webcomponentsjs-v1/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
@@ -21,10 +27,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
   <script>
     (function() {
-      // Flag to enable takeRecords/flush for CustomElements v1 polyfill.
-      // https://github.com/webcomponents/custom-elements#differences-from-spec
-      customElements.enableFlush = true;
-
       function XCustom() {
         if (window.Reflect) {
           return Reflect.construct(HTMLElement, [], XCustom)
@@ -177,7 +179,7 @@ describe('<test-fixture>', function () {
 
     describe('for a dom with a single root element', function () {
       it('returns a reference to the root element', function () {
-        expect(el).to.be.instanceOf(HTMLElement);
+        expect(el).to.be.instanceOf(_HTMLElement);
       });
     });
 
@@ -196,8 +198,8 @@ describe('<test-fixture>', function () {
 
       it('returns an array of root elements', function () {
         expect(els).to.be.instanceOf(Array);
-        expect(els[0]).to.be.instanceOf(HTMLElement);
-        expect(els[1]).to.be.instanceOf(HTMLElement);
+        expect(els[0]).to.be.instanceOf(_HTMLElement);
+        expect(els[1]).to.be.instanceOf(_HTMLElement);
       });
     });
 
@@ -215,10 +217,10 @@ describe('<test-fixture>', function () {
 
       it('returns an array with elements grouped by template', function () {
         expect(groups).to.be.instanceOf(Array);
-        expect(groups[0]).to.be.instanceOf(HTMLElement);
+        expect(groups[0]).to.be.instanceOf(_HTMLElement);
         expect(groups[1]).to.be.instanceOf(Array);
-        expect(groups[1][0]).to.be.instanceOf(HTMLElement);
-        expect(groups[1][1]).to.be.instanceOf(HTMLElement);
+        expect(groups[1][0]).to.be.instanceOf(_HTMLElement);
+        expect(groups[1][1]).to.be.instanceOf(_HTMLElement);
       });
     });
 
@@ -232,7 +234,7 @@ describe('<test-fixture>', function () {
       });
 
       it('returns a single element if the template has a single child', function() {
-        expect(el).to.be.instanceOf(HTMLElement);
+        expect(el).to.be.instanceOf(_HTMLElement);
       });
 
       it('returns multiple elements if the template has multiple children', function() {


### PR DESCRIPTION
When `test-fixture` stamps the template contents, it needs to force synchrony also for `ShadyDOM` in order to update styles of distributed content. See this simplified example:
http://output.jsbin.com/danokiy/2/?wc-shadydom=true
Notice that the content has a non-zero rect immediately after getting stamped and attached.
By forcing `ShadyDOM.flush()`, styles get immediately applied.

Not very happy to introduce this in `test-fixture`, but I don't see another place where to fix this.
Without this fix, all users of `test-fixture` that will be migrating to 2.0 would have to manually call `ShadyDOM.flush()` in their test suites.

@cdata @sorvell do you think this is the right spot to do this? I can add unit tests if this looks good to you.