### PR TITLE
Move WCT to devDependenceis

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/polymerelements/test-fixture/issues"
   },
   "homepage": "https://github.com/polymerelements/test-fixture#readme",
-  "dependencies": {
+  "devDependencies": {
     "web-component-tester": "^6.0.0-prerelease.5"
   }
 }


### PR DESCRIPTION
test-fixture doesn't actually need wct, does it?

Fixes https://github.com/Polymer/web-component-tester/issues/498 and https://github.com/Polymer/web-component-tester/issues/510