### PR TITLE
fix modulizer

### DIFF
--- a/test/test-fixture.html
+++ b/test/test-fixture.html
@@ -105,6 +105,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 describe('test-fixture import', function() {
   it('loads from test-fixture import', function() {
     var importNode = document.getElementById('test-fixture-import');
+    if (!importNode) {
+      // this element is a module
+      this.skip();
+    }
     expect(importNode.import).to.not.be.null;
   });
 });


### PR DESCRIPTION
skip tests that rely on an html import node existing.